### PR TITLE
Add option to instantly create file

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,4 @@ All settings can be turned on and off via the built-in settings tab (`cmd-,`) an
 - Show Files In Auto Completion
 - Suggest Current File Path
 - Remove whole folder
+- Create file instantly

--- a/lib/advanced-new-file-view.coffee
+++ b/lib/advanced-new-file-view.coffee
@@ -2,6 +2,7 @@
 fs = require 'fs'
 path = require 'path'
 mkdirp = require 'mkdirp'
+touch = require 'touch'
 
 module.exports =
 class AdvancedFileView extends View
@@ -15,6 +16,7 @@ class AdvancedFileView extends View
     showFilesInAutoComplete: false
     caseSensitiveAutoCompletion: false
     addTextFromSelection: false
+    createFileInstantly: false
 
   @activate: (state) ->
     @advancedFileView = new AdvancedFileView(state.advancedFileViewState)
@@ -156,6 +158,8 @@ class AdvancedFileView extends View
         if /\/$/.test(pathToCreate)
           mkdirp pathToCreate
         else
+          if atom.config.get 'advanced-new-file.createFileInstantly'
+            touch pathToCreate
           atom.workspace.open pathToCreate
       catch error
         @setMessage 'alert', error.message

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "mkdirp": "^0.3.5",
-    "atom-space-pen-views": "^2.0.3"
+    "atom-space-pen-views": "^2.0.3",
+    "touch": "0.0.3"
   }
 }


### PR DESCRIPTION
Could be helpful in some cases. For example, when using Linter plugin - it shows errors on attempt to lint file that doesn't exist (yet). Also, sometimes I just need to create an empty file and this option will remove extra `Cmd+S` action (yep, I'm lazy).
