### PR TITLE
Build directory tree when creating file instantly.

### DIFF
--- a/lib/advanced-new-file-view.coffee
+++ b/lib/advanced-new-file-view.coffee
@@ -154,11 +154,13 @@ class AdvancedFileView extends View
 
     for relativePath in relativePaths
       pathToCreate = path.join(@referenceDir(), relativePath)
+      createWithin = path.dirname(pathToCreate)
       try
         if /\/$/.test(pathToCreate)
           mkdirp pathToCreate
         else
           if atom.config.get 'advanced-new-file.createFileInstantly'
+            mkdirp createWithin unless fs.existsSync(createWithin) and fs.statSync(createWithin)
             touch pathToCreate
           atom.workspace.open pathToCreate
       catch error


### PR DESCRIPTION
This PR adds a line to handle cases when `advanced-new-file.createFileInstantly` is set to `true` and the user tries to create a new file within a new directory. Previously, the call to `touch` would fail because the parent directory did not yet exist; with this update, the parent directory tree is created before `touch` is called.

Thanks for all your hard work on this package! It's completely invaluable.
