### PR TITLE
Add link to advanced-open-file package

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 ## Please switch to Advanced Open File
 
+Advanced New File is no longer being maintained. Please switch to Advanced Open File: [advanced-open-file](https://atom.io/packages/advanced-open-file)
+
+## Advanced New File
+
 Advanced New File is fork of existing package Fancy New File. First of all let me thank rev087 - author of Fancy New File for great work.
 I forked this folder because old one wasn't maintained for few months and I couldn't contact the author.
 


### PR DESCRIPTION
Make it clear that advanced-new-file is no longer being maintained and provide a link to advanced-open-file.
